### PR TITLE
Prevent deopt from leaking arguments & misc cleanup.

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Install with one of:
 npm install --save smart-mixin
 
 # will expose window.smartMixin or the smartMixin AMD module
-curl 'wzrd.in/standalone/smart-mixin@1' > vendor/smart-mixin.js 
+curl 'wzrd.in/standalone/smart-mixin@1' > vendor/smart-mixin.js
 ```
 
 Usage:
@@ -50,7 +50,7 @@ var mixIntoGameObject = mixins({
     countChickens: mixins.REDUCE_LEFT,
     countDucks: mixins.REDUCE_RIGHT,
 
-    
+
 
     // define your own handler for it
     // the two operands are the value of onKeyPress on each object
@@ -59,20 +59,17 @@ var mixIntoGameObject = mixins({
     // here we allow event.stopImmediatePropagation() to prevent the next mixin from
     // being called
     // key is 'onKeyPress' here, this allows reuse of these functions
-    // args is the arguments we were called with; treat it like an arraylike object
-    // thrower is a special function which attempts to improve the error stack by including
-    // the location where it was actually mixed in
     onKeyPress: function(left, right, key) {
         left = left || function(){};
         right = right || function(){};
-        return function(args, thrower){
+        return function(event){
             var event = args[0];
 
-            if (!event) thrower(TypeError(key + ' called without an event object'));
+            if (!event) throw new TypeError(key + ' called without an event object');
 
-            var ret = left.apply(this, args);
+            var ret = left.apply(this, arguments);
             if (event && !event.immediatePropagationIsStopped) {
-                var ret2 = right.apply(this, args);    
+                var ret2 = right.apply(this, arguments);
             }
             return ret || ret2;
         }
@@ -97,7 +94,7 @@ var mixIntoGameObject = mixins({
 // simple usage example
 var mixin = {
     getState(foo){
-        return {bar: foo+1}    
+        return {bar: foo+1}
     }
 };
 

--- a/test/a_mixin_utils.js
+++ b/test/a_mixin_utils.js
@@ -17,8 +17,8 @@ describe('mixin utilities', function(){
         it('calls the correct function', function(){
             var left = sinon.stub().withArgs(7).returns(13),
                 right = sinon.stub().withArgs(8).returns(14);
-            var res1 = mixins.ONCE(left, undefined, 'LeftTest')([7]);
-            var res2 = mixins.ONCE(undefined, right, 'RightTest')([8]);
+            var res1 = mixins.ONCE(left, undefined, 'LeftTest')(7);
+            var res2 = mixins.ONCE(undefined, right, 'RightTest')(8);
 
             expect(left.called).to.be.ok();
             expect(right.called).to.be.ok();
@@ -28,10 +28,20 @@ describe('mixin utilities', function(){
 
     describe('mixins.MANY', function(){
         it('calls both functions', function(){
-            var left = sinon.stub().returns(13);
-            var right = sinon.stub().returns(14);
+            var left = sinon.stub().withArgs(9).returns(13);
+            var right = sinon.stub().withArgs(9).returns(14);
 
-            var res = mixins.MANY(left, right, "callsBoth")([9]);
+            var res = mixins.MANY(left, right, "callsBoth")(9);
+            expect(left.called).to.be.ok();
+            expect(right.called).to.be.ok();
+            expect(res).to.be(13);
+        });
+
+        it('passes multiple arguments to both functions', function(){
+            var left = sinon.stub().withArgs(1, 2, 3, 'foo').returns(13);
+            var right = sinon.stub().withArgs(1, 2, 3, 'foo').returns(14);
+
+            var res = mixins.MANY(left, right, "callsBoth")(1, 2, 3, 'foo');
             expect(left.called).to.be.ok();
             expect(right.called).to.be.ok();
             expect(res).to.be(13);
@@ -40,10 +50,10 @@ describe('mixin utilities', function(){
 
     describe('mixins.REDUCE_LEFT', function(){
         it('calls both functions in master to mixin order', function(){
-            var left = sinon.stub().returns(13);
-            var right = sinon.stub().returns(14);
+            var left = sinon.stub().withArgs(9).returns(13);
+            var right = sinon.stub().withArgs(9).returns(14);
 
-            var res = mixins.REDUCE_LEFT(left, right, "callsBoth")([9]);
+            var res = mixins.REDUCE_LEFT(left, right, "callsBoth")(9);
             expect(left.called).to.be.ok();
             expect(right.called).to.be.ok();
             expect(res).to.be(14);
@@ -52,10 +62,10 @@ describe('mixin utilities', function(){
 
     describe('mixins.REDUCE_RIGHT', function(){
         it('calls both functions in mixin to master order', function(){
-            var left = sinon.stub().returns(13);
-            var right = sinon.stub().returns(14);
+            var left = sinon.stub().withArgs(9).returns(13);
+            var right = sinon.stub().withArgs(9).returns(14);
 
-            var res = mixins.REDUCE_RIGHT(left, right, "callsBoth")([9]);
+            var res = mixins.REDUCE_RIGHT(left, right, "callsBoth")(9);
             expect(left.called).to.be.ok();
             expect(right.called).to.be.ok();
             expect(res).to.be(13);
@@ -68,7 +78,7 @@ describe('mixin utilities', function(){
             var right = sinon.stub().returns(rightRet);
             var fn = mixins.MANY_MERGED(left, right, "manyMerged");
             return function(){
-                var res = fn([], function(e){ throw e });
+                var res = fn();
                 expect(left.called).to.be.ok();
                 expect(right.called).to.be.ok();
                 return res;


### PR DESCRIPTION
This is a breaking change; custom mixin functions have a changed signature,
as they don't leak arguments or use an inline slice.

The default signature had two issues:
1. I thought `(args, thrower) => any` was a surprising signature that custom mixin authors might not expect. The addition of the `thrower` object has only small benefit and is an extra allocation.
2. The way the args were being created caused deopt.

I think this simplifies the code and usage a good bit. If you're using a `mixins` function directly, you no longer have to know that you have to pass arguments as an array (e.g. `mixins.MANY_MERGED(a,b)([1,2,3])`).

If you don't agree with the signature change, I'm happy to just fix the deopt and keep the old signature.
